### PR TITLE
Added reposition function

### DIFF
--- a/jquery.ui.datepicker.monthyearpicker.js
+++ b/jquery.ui.datepicker.monthyearpicker.js
@@ -65,6 +65,8 @@ MIT (http://dev.jquery.com/browser/trunk/jquery/MIT-LICENSE.txt) licenses. */
 			uidptitle_link.click(function(){$.datepicker._toggleDisplay_MonthYearPicker('#' + inst.id, 2); return false;});
 
 			inst.dpDiv.children('table.ui-datepicker-calendar').after(this._generateExtraHTML_MonthYearPicker(inst));
+		
+			this._reposition_MonthYearPicker(inst);
 		},
 		
 		//focus the date input field

--- a/jquery.ui.datepicker.monthyearpicker.js
+++ b/jquery.ui.datepicker.monthyearpicker.js
@@ -133,6 +133,14 @@ MIT (http://dev.jquery.com/browser/trunk/jquery/MIT-LICENSE.txt) licenses. */
 				this._toggleDisplay_MonthYearPicker(id, 2);
 			}
 		},
+		
+		_reposition_MonthYearPicker: function (inst) {
+	            inst.dpDiv.position({
+	                my: "left top",
+	                at: "left bottom",
+	                of: $(inst.input)
+	            });
+	        },
 
 		_toggleDisplay_MonthYearPicker: function(inst, screen, input) {
 			if(typeof inst == 'string')  {
@@ -209,6 +217,8 @@ MIT (http://dev.jquery.com/browser/trunk/jquery/MIT-LICENSE.txt) licenses. */
 					$('table.ui-datepicker-calendar').hide();
 					$('.ui-datepicker-select-month').show();
 					$('.ui-datepicker-select-year').hide();
+					this._reposition_MonthYearPicker(inst);
+					
 					break;
 				case 3:
 					//year picker
@@ -272,6 +282,7 @@ MIT (http://dev.jquery.com/browser/trunk/jquery/MIT-LICENSE.txt) licenses. */
 					$('table.ui-datepicker-calendar').hide();
 					$('.ui-datepicker-select-month').hide();
 					$('.ui-datepicker-select-year').show();
+					this._reposition_MonthYearPicker(inst);
 					
 					break;
 			}


### PR DESCRIPTION
When there isn’t enough room beneath the input the datepicker will display above the input.
When this happens and you go to the "Select Month" view, there will be a gap between the picker and the input.
This occurs because the list of months is smaller than the list of days. The same problem occurs when selecting a year.
This can be resolved by repositioning the picker.
